### PR TITLE
Robust Rt estimation at very low case numbers

### DIFF
--- a/R/model_infections.R
+++ b/R/model_infections.R
@@ -865,20 +865,18 @@ add_seeding_intercept_prior <- function(
     cli::cli_warn(paste0(
       "Warning from ",
       help_seeding_f, ": ",
-      "The 5% quantile (`intercept_prior_q5`) was slightly raised to be ",
-      "at least 1 infection."
+      "The 5% quantile (`intercept_prior_q5`) is very low ",
+      "(less than 1 infection)."
     ))
-    intercept_prior_q5 <- 1
   }
 
   if (!is.null(intercept_prior_q95) && intercept_prior_q95 < 2) {
     cli::cli_warn(paste0(
       "Warning from ",
       help_seeding_f, ": ",
-      "The 95% quantile (`intercept_prior_q95`) was slightly raised to be ",
-      "at least 2 infections."
+      "The 95% quantile (`intercept_prior_q95`) is very low ",
+      "(less than 2 infections)."
     ))
-    intercept_prior_q95 <- 2
   }
 
   if (!is.null(intercept_prior_q5) && !is.null(intercept_prior_q95)) {

--- a/R/model_shedding.R
+++ b/R/model_shedding.R
@@ -201,8 +201,17 @@ load_variation_none <- function(modeldata = modeldata_init()) {
 #'   mean equal to the average `load_per_case` and a coefficient of variation to
 #'   be estimated.
 #'
+#' @param cv_prior_mu Mean of the truncated normal prior for the coefficient of
+#'   individual-level variation. Default is a CV of 1, which means that
+#'   approximately 60% of individuals shed less than the mean, and approximately
+#'   10% of individuals shed less than 10% of the mean.
+#' @param cv_prior_sigma Standard deviation of the truncated normal prior for
+#'   the coefficient of individual-level variation. If this is set to zero, the
+#'   coefficient of variation is fixed to the mean.
+#'
 #' @details Note that measurement noise and individual-level load variation
-#'   might not be jointly identifiable.
+#'   might not be jointly identifiable. This is why the coefficient of variation
+#'   of the individual-level load is fixed by default.
 #'
 #' @details Also note that the accuracy of the variation model depends on the
 #'   estimated number of cases to be on the right scale (which in turn depends
@@ -217,18 +226,13 @@ load_variation_none <- function(modeldata = modeldata_init()) {
 #'   - the population-level CV will be underestimated (especially if the prior
 #'   on the individual-level CV is strong)
 #'
-#' @param cv_prior_mu Mean of the truncated normal prior for the coefficient of
-#'   individual-level variation.
-#' @param cv_prior_sigma Standard deviation of the truncated normal prior for
-#'   the coefficient of individual-level variation.
-#'
 #' @inheritParams template_model_helpers
 #' @inherit modeldata_init return
 #' @export
 #' @family {load variation models}
 load_variation_estimate <- function(
-    cv_prior_mu = 0,
-    cv_prior_sigma = 1,
+    cv_prior_mu = 1,
+    cv_prior_sigma = 0,
     modeldata = modeldata_init()) {
   modeldata$load_vari <- 1
   modeldata$nu_zeta_prior <- set_prior(

--- a/inst/stan/EpiSewer_main.stan
+++ b/inst/stan/EpiSewer_main.stan
@@ -407,9 +407,9 @@ model {
   if (I_sample) {
     if (I_overdispersion) {
       target += normal_prior_lpdf(I_xi | I_xi_prior, 0); // truncated normal
-      I[1 : (L + S + D + T)] ~ normal(iota, sqrt(iota .* (1 + iota * (param_or_fixed(I_xi, I_xi_prior) ^ 2)))); // approximates negative binomial
+      I[1 : (L + S + D + T)] ~ normal(iota, iota .* soft_upper(sqrt(iota .* (1 + iota * (param_or_fixed(I_xi, I_xi_prior) ^ 2)))./iota, 0.5, 10)) T[0, ]; // approximates negative binomial
     } else {
-      I[1 : (L + S + D + T)] ~ normal(iota, sqrt(iota)); // approximates Poisson
+      I[1 : (L + S + D + T)] ~ normal(iota, iota .* soft_upper(sqrt(iota)./iota, 0.5, 10)) T[0, ]; // approximates Poisson
     }
   }
 

--- a/inst/stan/functions/dist_gamma.stan
+++ b/inst/stan/functions/dist_gamma.stan
@@ -6,6 +6,13 @@ real gamma2_lpdf(vector y, vector mean, real sd) {
   return gamma_lpdf(y | alpha, beta);
 }
 
+real gamma2_lpdf(vector y, vector mean, vector sd) {
+  int n = num_elements(y);
+  vector[n] alpha = (mean ./ sd)^2;
+  vector[n] beta = mean ./ (sd^2);
+  return gamma_lpdf(y | alpha, beta);
+}
+
 real gamma2_sum_lpdf(vector y, real mean, real sd, vector N) {
   int n = num_elements(y);
   vector[n] alpha = N * ((mean / sd)^2);

--- a/inst/stan/functions/dist_lognormal.stan
+++ b/inst/stan/functions/dist_lognormal.stan
@@ -157,7 +157,7 @@ vector lognormal4_rng(vector mean_log, vector cv) {
 // --------------------------------------------------------
 
 /**
-  * The log of the lognormal density given mean on log scale and coefficient of
+  * The log of the lognormal density given mean and coefficient of
   * variation on unit scale
   *
   * @param y vector with observed data
@@ -176,7 +176,7 @@ real lognormal5_lpdf(vector y, vector mean, real cv) {
 }
 
 /**
-  * The log of the lognormal density given mean on log scale and coefficient of
+  * The log of the lognormal density given mean and coefficient of
   * variation on unit scale
   *
   * @param y vector with observed data
@@ -195,7 +195,7 @@ real lognormal5_lpdf(vector y, vector mean, vector cv) {
 }
 
 /**
-  * Generate lognormal variate given mean on log scale and coefficient of
+  * Generate lognormal variate given mean and coefficient of
   * variation on unit scale
   *
   * @param mean vector of means
@@ -212,7 +212,7 @@ vector lognormal5_rng(vector mean, real cv) {
 }
 
 /**
-  * Generate lognormal variate given mean on log scale and coefficient of
+  * Generate lognormal variate given mean and coefficient of
   * variation on unit scale
   *
   * @param mean vector of means
@@ -226,6 +226,42 @@ vector lognormal5_rng(vector mean, vector cv) {
   vector[n] sigma2 = log1p(cv^2);
   vector[n] mu = log(mean) - sigma2/2;
   return to_vector(lognormal_rng(mu, sqrt(sigma2)));
+}
+
+/**
+  * The log of the lognormal density given mean and sd on unit scale
+  *
+  * @param y vector with observed data
+  *
+  * @param mean vector of means
+  *
+  * @param sd vector with standard deviation for each observation
+  *
+  * @return The log of the lognormal density of y
+  */
+real lognormal6_lpdf(vector y, vector mean, vector sd) {
+  int n = num_elements(y);
+  vector[n] sigma2 = log1p((sd ./ mean)^2);
+  vector[n] mu = log(mean) - sigma2/2;
+  return lognormal_lpdf(y | mu, sqrt(sigma2));
+}
+
+/**
+  * The log of the lognormal density given median and cv on unit scale
+  *
+  * @param y vector with observed data
+  *
+  * @param median vector of medians
+  *
+  * @param sd vector with standard deviation for each observation
+  *
+  * @return The log of the lognormal density of y
+  */
+real lognormal7_lpdf(vector y, vector median, vector cv) {
+  int n = num_elements(y);
+  vector[n] sigma2 = log1p(cv^2);
+  vector[n] mu = log(median);
+  return lognormal_lpdf(y | mu, sqrt(sigma2));
 }
 
 // --------------------------------------------------------

--- a/inst/stan/functions/link.stan
+++ b/inst/stan/functions/link.stan
@@ -10,6 +10,13 @@ Helper for link functions
   }
 
   /**
+  * Soft upper limit using the softplus function
+  */
+  vector soft_upper(vector x, real u, real k) {
+    return(u - softplus(u - x, k));
+  }
+
+  /**
   * Logistic
   */
   vector logistic(vector x, real c, real a, real k) {

--- a/man/load_variation_estimate.Rd
+++ b/man/load_variation_estimate.Rd
@@ -5,17 +5,20 @@
 \title{Estimate individual-level load variation}
 \usage{
 load_variation_estimate(
-  cv_prior_mu = 0,
-  cv_prior_sigma = 1,
+  cv_prior_mu = 1,
+  cv_prior_sigma = 0,
   modeldata = modeldata_init()
 )
 }
 \arguments{
 \item{cv_prior_mu}{Mean of the truncated normal prior for the coefficient of
-individual-level variation.}
+individual-level variation. Default is a CV of 1, which means that
+approximately 60\% of individuals shed less than the mean, and approximately
+10\% of individuals shed less than 10\% of the mean.}
 
 \item{cv_prior_sigma}{Standard deviation of the truncated normal prior for
-the coefficient of individual-level variation.}
+the coefficient of individual-level variation. If this is set to zero, the
+coefficient of variation is fixed to the mean.}
 
 \item{modeldata}{A \code{modeldata} object to which the above model specifications
 should be added. Default is an empty model given by \code{\link[=modeldata_init]{modeldata_init()}}. Can
@@ -39,7 +42,8 @@ be estimated.
 }
 \details{
 Note that measurement noise and individual-level load variation
-might not be jointly identifiable.
+might not be jointly identifiable. This is why the coefficient of variation
+of the individual-level load is fixed by default.
 
 Also note that the accuracy of the variation model depends on the
 estimated number of cases to be on the right scale (which in turn depends


### PR DESCRIPTION
When the expected estimated number of infections is very low, i.e. significantly below 1, the stochastic renewal model starts to break down: As the coefficient of variation of infection noise gets much larger than 0.5, continuous approximations to the Poisson or Negative Binomial offspring distribution become invalid and bias Rt either downwards (e.g. when using a Truncated normal approximation) or upwards (e.g. when using a log-normal or Gamma approximation).

Ideally, we shouldn't be estimating Rt in such regimes, however this can happen when user misspecify the load per case or when modeling several seasonal waves with an in-between period where there are virtually no infections in the sampled catchment, and get imported again from elsewhere.

As a current workaround, this PR limits the CV of infections to 0.5 via a soft constraint that only has a relevant effect when infections are very low (less than 5 infections per day). This way, the bias in Rt is avoided. A future PR will make the specification of the load per case less error prone and add additional warnings for low infection numbers. For now, at least the risk that users obtain biased Rt estimates without noticing is avoided.