### PR TITLE
Bugfix lazy evaluation

### DIFF
--- a/R/utils_lazy.R
+++ b/R/utils_lazy.R
@@ -119,6 +119,7 @@ tbp <- function(f_name, f_expr,
                      data = list(), assumptions = list(),
                      required_data = c(), required_assumptions = c()) {
     for(n in names(d_lazy)) {
+      f_lazy$env <- rlang::env_clone(f_lazy$env)
       assign(n, d_lazy[[n]], f_lazy$env)
     }
     f_lazy$env <- update_env(

--- a/R/utils_modeldata.R
+++ b/R/utils_modeldata.R
@@ -385,7 +385,7 @@ modeldata_validate <- function(modeldata,
     cli::cli_abort("Please supply a modeldata object.")
   }
 
-  for (i in 1:4) { # update three times to catch all lazy evals
+  for (i in 1:5) { # update several times to catch all lazy evals
     modeldata <- modeldata_update(
       modeldata,
       data = data, assumptions = assumptions, throw_error = F

--- a/README.Rmd
+++ b/README.Rmd
@@ -209,7 +209,7 @@ ww_assumptions <- sewer_assumptions(
   generation_dist = get_discrete_gamma_shifted(gamma_mean = 3, gamma_sd = 2.4),
   shedding_dist = get_discrete_gamma(gamma_shape = 0.929639, gamma_scale = 7.241397),
   shedding_reference = "symptom_onset", # shedding load distribution is relative to symptom onset
-  incubation_dist = get_discrete_gamma(gamma_shape = 8.5, gamma_scale = 0.4),
+  incubation_dist = get_discrete_gamma(gamma_shape = 8.5, gamma_scale = 0.4)
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ ww_assumptions <- sewer_assumptions(
   generation_dist = get_discrete_gamma_shifted(gamma_mean = 3, gamma_sd = 2.4),
   shedding_dist = get_discrete_gamma(gamma_shape = 0.929639, gamma_scale = 7.241397),
   shedding_reference = "symptom_onset", # shedding load distribution is relative to symptom onset
-  incubation_dist = get_discrete_gamma(gamma_shape = 8.5, gamma_scale = 0.4),
+  incubation_dist = get_discrete_gamma(gamma_shape = 8.5, gamma_scale = 0.4)
 )
 ```
 


### PR DESCRIPTION
This PR fixes a bug in the lazy evaluation procedure used to obtain data and assumptions from `sewer_data` and `sewer_assumptions`. The bug was that the internal environments for lazy evaluation of modeling modules objects would be modified if the EpiSewer model is fitted. This could lead to unexpected behaviour and bugs if the same module is used for different model fits with different data/assumptions. The bug has been fixed by ensuring that environments are cloned before modifying them during lazy evaluation.