### PR TITLE
Plot concentrations fix

### DIFF
--- a/R/sewer_plot.R
+++ b/R/sewer_plot.R
@@ -417,6 +417,10 @@ plot_R <- function(results, draws = FALSE, ndraws = NULL,
 #'   "pp_check", the observations are ordered by concentration and plotted
 #'   against the predicted concentration (useful for posterior predictive
 #'   checks).
+#' @param obs_size Size of the observed concentration points. Default is 1.5.
+#' @param obs_shape Shape of the observed concentration points. Default is 4.
+#' @param obs_forecast_shape Shape of the observed concentration points for
+#'  forecasted values. Default is 8.
 #' @inheritParams plot_infections
 #'
 #' @details When plotting a posterior predictive check (`type="pp_check"`), each
@@ -443,7 +447,10 @@ plot_concentration <- function(results = NULL, measurements = NULL, flows = NULL
                                date_col = "date",
                                outlier_col = "is_outlier",
                                type = "time",
-                               intervals = c(0.5, 0.95)
+                               intervals = c(0.5, 0.95),
+                               obs_size = 1.5,
+                               obs_shape = 4,
+                               obs_forecast_shape = 8
                                ) {
 
   if (!(type %in% c("time","pp_check"))) {
@@ -697,7 +704,8 @@ plot_concentration <- function(results = NULL, measurements = NULL, flows = NULL
           geom_point(
             data = measurements,
             aes(y = concentration),
-            color = ifelse(is.null(results),"black","#a6a6a6"), shape = 4
+            color = ifelse(is.null(results),"black","#a6a6a6"),
+            shape = obs_shape, size = obs_size
           )
         }
       } +
@@ -706,7 +714,7 @@ plot_concentration <- function(results = NULL, measurements = NULL, flows = NULL
           geom_point(
             data = measurements[.outlier == TRUE, ],
             aes(y = concentration),
-            color = "red", shape = 4
+            color = "red", shape = obs_shape, size = obs_size
           )
         }
       } +
@@ -714,7 +722,9 @@ plot_concentration <- function(results = NULL, measurements = NULL, flows = NULL
         if (!is.null(measurements_modeled)) {
           geom_point(
             data = measurements_modeled[model==base_model & type == "observed", c("date","concentration")],
-            aes(y = concentration), shape = 4, color = "black"
+            aes(y = concentration),
+            shape = obs_shape, size = obs_size,
+            color = "black"
           )
         }
       } +
@@ -722,7 +732,8 @@ plot_concentration <- function(results = NULL, measurements = NULL, flows = NULL
         if (!is.null(measurements_modeled)) {
           geom_point(
             data = measurements_modeled[model==base_model & type == "future", c("date","concentration")],
-            aes(y = concentration), shape = 8, color = "black"
+            aes(y = concentration), color = "black",
+            shape = obs_forecast_shape, size = obs_size
           )
         }
       } +
@@ -730,7 +741,8 @@ plot_concentration <- function(results = NULL, measurements = NULL, flows = NULL
         if (!is.null(measurements_modeled)) {
           geom_point(
             data = measurements_modeled[model!=base_model & type == "observed"],
-            aes(y = concentration, color = model), shape = 4
+            aes(y = concentration, color = model),
+            shape = obs_shape, size = obs_size
           )
         }
       } +
@@ -738,7 +750,8 @@ plot_concentration <- function(results = NULL, measurements = NULL, flows = NULL
         if (!is.null(measurements_modeled)) {
           geom_point(
             data = measurements_modeled[model!=base_model & type == "future"],
-            aes(y = concentration, color = model), shape = 8
+            aes(y = concentration, color = model),
+            shape = obs_forecast_shape, size = obs_size
           )
         }
       } +
@@ -797,7 +810,8 @@ plot_concentration <- function(results = NULL, measurements = NULL, flows = NULL
         if (!is.null(measurements_modeled)) {
           geom_point(
             data = measurements_modeled,
-            aes(y = concentration), color = "black", shape = 4
+            aes(y = concentration), color = "black",
+            shape = obs_shape, size = obs_size
           )
         }
       } +
@@ -806,7 +820,7 @@ plot_concentration <- function(results = NULL, measurements = NULL, flows = NULL
           geom_point(
             data = measurements_modeled |> filter(.outlier),
             aes(y = concentration),
-            color = "red", shape = 4
+            color = "red", shape = obs_shape, size = obs_size
           )
         }
       } +

--- a/man/plot_concentration.Rd
+++ b/man/plot_concentration.Rd
@@ -25,7 +25,10 @@ plot_concentration(
   date_col = "date",
   outlier_col = "is_outlier",
   type = "time",
-  intervals = c(0.5, 0.95)
+  intervals = c(0.5, 0.95),
+  obs_size = 1.5,
+  obs_shape = 4,
+  obs_forecast_shape = 8
 )
 }
 \arguments{
@@ -104,6 +107,13 @@ which identifies outlier measurements (for example added by
 "pp_check", the observations are ordered by concentration and plotted
 against the predicted concentration (useful for posterior predictive
 checks).}
+
+\item{obs_size}{Size of the observed concentration points. Default is 1.5.}
+
+\item{obs_shape}{Shape of the observed concentration points. Default is 4.}
+
+\item{obs_forecast_shape}{Shape of the observed concentration points for
+forecasted values. Default is 8.}
 }
 \value{
 A ggplot object showing predicted and observed concentrations over


### PR DESCRIPTION
This PR fixes the shapes of plotted future observations when a `forecast_horizon` smaller than the modeled forecast horizon is used for plotting. It also adds customization options for the shape and size of the plotted observations.