### PR TITLE
Extended seeding

### DIFF
--- a/R/sewer_calibrate.R
+++ b/R/sewer_calibrate.R
@@ -56,7 +56,7 @@ get_load_curve_crude <- function(
   } else if (impute_zero > 0) {
     if (impute_zero_runs) {
       n_run <- 0
-      for (t in 1:nrow(loads)) {
+      for (t in nrow(loads):1) { # backward in time
         if (loads[t, concentration] == 0) {
           n_run <- n_run + 1
           # if n zeros have been observed in a row, the posterior expectation

--- a/R/sewer_summary.R
+++ b/R/sewer_summary.R
@@ -39,7 +39,7 @@
 #' @export
 summarize_fit <- function(fit, data, .metainfo, intervals = c(0.5, 0.95), ndraws = 50) {
   summary <- list()
-  T_shift_R <- with(data, L + S + D - G)
+  T_shift_R <- with(data, L + S + D - (G + se))
   T_shift_latent <- with(data, L + S + D)
   T_shift_onset <- with(data, S)
   T_shift_load <- with(data, 0)
@@ -76,7 +76,7 @@ summarize_fit <- function(fit, data, .metainfo, intervals = c(0.5, 0.95), ndraws
     list(R_samples, expected_I_samples, I_samples)
     )
   min_date <- all_samples[, min(date)]
-  last_seeding <- min_date + (data$G * 2)
+  last_seeding <- min_date + (data$G * 2) + data$se # se is seeding extension
   all_samples[, seeding := date < last_seeding]
   setcolorder(all_samples, c(".draw", "date", "type", "seeding"))
   all_samples[, type := factor(type, levels = c("estimate", "forecast"))]

--- a/inst/stan/functions/renewal.stan
+++ b/inst/stan/functions/renewal.stan
@@ -7,6 +7,8 @@
 *
 * @param G Maximum generation interval
 *
+* @param se Length of shedding phase extension (beyond G)
+*
 * @param gi_rev The generation interval distribution in reversed format
 *
 * @param I The sampled infections (see model block). These should include the
@@ -14,18 +16,18 @@
 *
 * @return The expected infections from time 1:T
 */
-vector renewal_process_stochastic(int T, vector R, int G, vector gi_rev, vector I) {
+vector renewal_process_stochastic(int T, vector R, int G, int se, vector gi_rev, vector I) {
   vector[T] iota;
   for (t in 1:T) {
-    iota[t] = R[t] * dot_product(gi_rev, I[t:(G+t-1)]);
+    iota[t] = R[t] * dot_product(gi_rev, I[(t+se):(G+se+t-1)]);
   }
   return(iota);
 }
 
-vector log_renewal_process_stochastic(int T, vector R_log, int G, vector gi_rev_log, vector I_log) {
+vector log_renewal_process_stochastic(int T, vector R_log, int G, int se, vector gi_rev_log, vector I_log) {
   vector[T] iota_log;
   for (t in 1:T) {
-    iota_log[t] = R_log[t] + log_dot_product(gi_rev_log, I_log[t:(G+t-1)]);
+    iota_log[t] = R_log[t] + log_dot_product(gi_rev_log, I_log[(t+se):(G+se+t-1)]);
   }
   return(iota_log);
 }
@@ -44,80 +46,80 @@ vector log_renewal_process_stochastic(int T, vector R_log, int G, vector gi_rev_
 * // Note however that the non-centered parameterization does not work well for
 * // the renewal model (longer runtime and higher chance of divergent transitions).
 */
-array[] vector renewal_process_stochastic_noncentered(int T, vector R, int G, vector gi_rev, vector iota, vector I_raw, real I_xi) {
-  vector[G+T] iota_tmp = iota;
-  vector[G+T] I;
+array[] vector renewal_process_stochastic_noncentered(int T, vector R, int G, int se, vector gi_rev, vector iota, vector I_raw, real I_xi) {
+  vector[(G+se)+T] iota_tmp = iota;
+  vector[(G+se)+T] I;
   real I_xi_squared = square(I_xi); // (I_xi = 0) => no overdispersion
-  I[1:G] = iota_tmp[1:G] + I_raw[1:G] .* sqrt(iota_tmp[1:G] .* (1 + iota_tmp[1:G]*I_xi_squared));
+  I[1:(G+se)] = iota_tmp[1:(G+se)] + I_raw[1:(G+se)] .* sqrt(iota_tmp[1:(G+se)] .* (1 + iota_tmp[1:(G+se)]*I_xi_squared));
   for (t in 1:T) {
-    iota_tmp[G+t] = R[t] * dot_product(gi_rev, I[t:(G+t-1)]);
-    I[G+t] = iota_tmp[G+t] + I_raw[G+t] * sqrt(iota_tmp[G+t] * (1 + iota_tmp[G+t]*I_xi_squared));
+    iota_tmp[(G+se)+t] = R[t] * dot_product(gi_rev, I[(t+se):(G+se+t-1)]);
+    I[(G+se)+t] = iota_tmp[(G+se)+t] + I_raw[(G+se)+t] * sqrt(iota_tmp[(G+se)+t] * (1 + iota_tmp[(G+se)+t]*I_xi_squared));
   }
   return {iota_tmp, I};
 }
 
-array[] vector log_renewal_process_stochastic_noncentered(int T, vector R_log, int G, vector gi_rev_log, vector iota_log, real I_xi, vector I_log_raw) {
-   vector[G+T] iota_log_tmp = iota_log;
-   vector[G+T] I_log;
-   I_log[1:G] = approx_negative_binomial_log_noncentered(iota_log_tmp[1:G], I_xi, I_log_raw[1:G]);
+array[] vector log_renewal_process_stochastic_noncentered(int T, vector R_log, int G, int se, vector gi_rev_log, vector iota_log, real I_xi, vector I_log_raw) {
+   vector[(G+se)+T] iota_log_tmp = iota_log;
+   vector[(G+se)+T] I_log;
+   I_log[1:(G+se)] = approx_negative_binomial_log_noncentered(iota_log_tmp[1:(G+se)], I_xi, I_log_raw[1:(G+se)]);
    for (t in 1:T) {
-     iota_log_tmp[G+t] = R_log[t] + log_dot_product(gi_rev_log, I_log[t:(G+t-1)]);
-     I_log[G+t] = approx_negative_binomial_log_noncentered(iota_log_tmp[G+t], I_xi, I_log_raw[G+t]);
+     iota_log_tmp[(G+se)+t] = R_log[t] + log_dot_product(gi_rev_log, I_log[(t+se):(G+se+t-1)]);
+     I_log[(G+se)+t] = approx_negative_binomial_log_noncentered(iota_log_tmp[(G+se)+t], I_xi, I_log_raw[(G+se)+t]);
    }
    return {iota_log_tmp, I_log};
 }
 
-vector renewal_process_deterministic(int T, vector R, int G, vector gi_rev, vector iota) {
-  vector[G+T] iota_tmp = iota;
+vector renewal_process_deterministic(int T, vector R, int G, int se, vector gi_rev, vector iota) {
+  vector[(G+se)+T] iota_tmp = iota;
   for (t in 1:T) {
-    iota_tmp[G+t] = R[t] * dot_product(gi_rev, iota_tmp[t:(G+t-1)]);
+    iota_tmp[(G+se)+t] = R[t] * dot_product(gi_rev, iota_tmp[(t+se):(G+se+t-1)]);
   }
-  return(iota_tmp[(G+1):(G+T)]);
+  return(iota_tmp[((G+se)+1):((G+se)+T)]);
 }
 
-vector log_renewal_process_deterministic(int T, vector R_log, int G, vector gi_rev_log, vector iota_log) {
-  vector[G+T] iota_log_tmp = iota_log;
+vector log_renewal_process_deterministic(int T, vector R_log, int G, int se, vector gi_rev_log, vector iota_log) {
+  vector[(G+se)+T] iota_log_tmp = iota_log;
   for (t in 1:T) {
-    iota_log_tmp[G+t] = R_log[t] + log_dot_product(gi_rev_log, iota_log_tmp[t:(G+t-1)]);
+    iota_log_tmp[(G+se)+t] = R_log[t] + log_dot_product(gi_rev_log, iota_log_tmp[(t+se):(G+se+t-1)]);
   }
-  return(iota_log_tmp[(G+1):(G+T)]);
+  return(iota_log_tmp[((G+se)+1):((G+se)+T)]);
 }
 
 // simulation of a renewal process
-array[] vector renewal_process_stochastic_sim_rng(int T, vector R, int G, vector gi_rev, vector iota, real I_xi) {
-  vector[G+T] iota_tmp = iota;
-  vector[G+T] I;
+array[] vector renewal_process_stochastic_sim_rng(int T, vector R, int G, int se, vector gi_rev, vector iota, real I_xi) {
+  vector[(G+se)+T] iota_tmp = iota;
+  vector[(G+se)+T] I;
   real I_xi_squared = square(I_xi); // (I_xi = 0) => no overdispersion
-  I[1:G] = normal_lb_rng(iota_tmp[1:G], sqrt(iota_tmp[1:G] .* (1 + iota_tmp[1:G]*I_xi_squared)), 0);
+  I[1:(G+se)] = normal_lb_rng(iota_tmp[1:(G+se)], sqrt(iota_tmp[1:(G+se)] .* (1 + iota_tmp[1:(G+se)]*I_xi_squared)), 0);
   for (t in 1:T) {
-    iota_tmp[G+t] = R[t] * dot_product(gi_rev, I[t:(G+t-1)]);
-    I[G+t] = normal_lb_rng(iota_tmp[G+t], sqrt(iota_tmp[G+t] * (1 + iota_tmp[G+t]*I_xi_squared)), 0);
+    iota_tmp[(G+se)+t] = R[t] * dot_product(gi_rev, I[(t+se):(G+se+t-1)]);
+    I[(G+se)+t] = normal_lb_rng(iota_tmp[(G+se)+t], sqrt(iota_tmp[(G+se)+t] * (1 + iota_tmp[(G+se)+t]*I_xi_squared)), 0);
   }
   return {iota_tmp, I};
 }
 
 // Approximation for autocorrelated infection noise
 // added to expected infection time series
-vector renewal_noise_correction(int T, int G, vector gi_rev, vector I_noise) {
-  vector[G+T] noise_tmp = I_noise;
+vector renewal_noise_correction(int T, int G, int se, vector gi_rev, vector I_noise) {
+  vector[(G+se)+T] noise_tmp = I_noise;
   for (t in 1:T) {
-    noise_tmp[G+t] = I_noise[G+t] + dot_product(gi_rev, noise_tmp[t:(G+t-1)]);
+    noise_tmp[(G+se)+t] = I_noise[(G+se)+t] + dot_product(gi_rev, noise_tmp[(t+se):(G+se+t-1)]);
   }
-  return((noise_tmp-I_noise)[(G+1):(G+T)]);
+  return((noise_tmp-I_noise)[((G+se)+1):((G+se)+T)]);
 }
 
-vector infectiousness(int T, int G, vector gi_rev, vector I) {
+vector infectiousness(int T, int G, int se, vector gi_rev, vector I) {
   vector[T] infness;
   for (t in 1:T) {
-    infness[t] = dot_product(gi_rev, I[t:(G+t-1)]);
+    infness[t] = dot_product(gi_rev, I[(t+se):(G+se+t-1)]);
   }
   return(infness);
 }
 
-vector log_infectiousness(int T, int G, vector gi_rev_log, vector I_log) {
+vector log_infectiousness(int T, int G, int se, vector gi_rev_log, vector I_log) {
   vector[T] infness;
   for (t in 1:T) {
-    infness[t] = log_dot_product(gi_rev_log, I_log[t:(G+t-1)]);
+    infness[t] = log_dot_product(gi_rev_log, I_log[(t+se):(G+se+t-1)]);
   }
   return(infness);
 }

--- a/man/load_per_case_calibrate.Rd
+++ b/man/load_per_case_calibrate.Rd
@@ -22,7 +22,7 @@ day. Must have at least a column with dates and a column with case numbers.}
 
 \item{min_cases}{This is an alternative to supplying a \code{data.frame} of cases.
 If \code{min_cases} is specified, then \code{load_per_case} is calibrated based on
-the smallest observed load in the wastewater. EpiSewer uses \code{min_cases = 10} as a default if no case data is supplied (see \code{\link[=sewer_assumptions]{sewer_assumptions()}}).}
+the smallest detected load in the wastewater. EpiSewer uses \code{min_cases = 10} as a default if no case data is supplied (see \code{\link[=sewer_assumptions]{sewer_assumptions()}}).}
 
 \item{ascertainment_prop}{Proportion of all cases that get detected /
 reported. Can be used to account for underreporting of infections. Default

--- a/man/seeding_estimate_constant.Rd
+++ b/man/seeding_estimate_constant.Rd
@@ -7,6 +7,7 @@
 seeding_estimate_constant(
   intercept_prior_q5 = NULL,
   intercept_prior_q95 = NULL,
+  extend = TRUE,
   modeldata = modeldata_init()
 )
 }
@@ -20,6 +21,18 @@ of cases (see details).}
 infections. Can be interpreted as an approximate upper bound. If NULL
 (default), this is computed from a crude empirical estimate of the number
 of cases (see details).}
+
+\item{extend}{Should the seeding phase be extended when concentrations are
+very low at the start of the measurement time series? If \code{TRUE}, then the
+seeding phase will be extended to the first date with three consecutive
+detects (i.e. non-zero measurements). The reproduction number will only be
+modeled from that date onward. This option often makes sense, as infection
+numbers are typically very low during a period with many non-detects, which
+can lead to sampling problems when estimating Rt. If you nevertheless want
+Rt estimates also for this period, you can use \code{extend = FALSE}. Note
+though that estimated reproduction numbers are not necessarily meaningful
+during periods with very low infection numbers, as transmission dynamics
+may be dominated by chance events and importations.}
 
 \item{modeldata}{A \code{modeldata} object to which the above model specifications
 should be added. Default is an empty model given by \code{\link[=modeldata_init]{modeldata_init()}}. Can

--- a/man/seeding_estimate_rw.Rd
+++ b/man/seeding_estimate_rw.Rd
@@ -9,6 +9,7 @@ seeding_estimate_rw(
   intercept_prior_q95 = NULL,
   rel_change_prior_mu = 0.05,
   rel_change_prior_sigma = 0.025,
+  extend = TRUE,
   modeldata = modeldata_init()
 )
 }
@@ -35,6 +36,18 @@ assumes that the daily change rate could be 5\% points higher or lower than
 your prior mean. For example, if \code{rel_change_prior_mu = 0.05} and
 \code{rel_change_prior_sigma = 0.025}, this means you expect the daily change
 rate to be between 0 (0\%) and 0.1 (10\%).}
+
+\item{extend}{Should the seeding phase be extended when concentrations are
+very low at the start of the measurement time series? If \code{TRUE}, then the
+seeding phase will be extended to the first date with three consecutive
+detects (i.e. non-zero measurements). The reproduction number will only be
+modeled from that date onward. This option often makes sense, as infection
+numbers are typically very low during a period with many non-detects, which
+can lead to sampling problems when estimating Rt. If you nevertheless want
+Rt estimates also for this period, you can use \code{extend = FALSE}. Note
+though that estimated reproduction numbers are not necessarily meaningful
+during periods with very low infection numbers, as transmission dynamics
+may be dominated by chance events and importations.}
 
 \item{modeldata}{A \code{modeldata} object to which the above model specifications
 should be added. Default is an empty model given by \code{\link[=modeldata_init]{modeldata_init()}}. Can


### PR DESCRIPTION
This PR adds an `extend` option (`TRUE` by default) to all seeding components, which will extend the seeding phase beyond the necessary minimum (maximum generation time) until the first date with three consecutive non-zero measurements (detects). This is to avoid sampling problems when the measurement time series starts with many non-detects. Moreover, infection numbers are generally quite low during such periods, so Rt estimation is anyway questionable.

The PR also brings more detailed warnings if the estimated number of infections is too low or too large, and improves the automatic calibration of the load per case when using the `min_cases` specification.