### PR TITLE
Fixes to plot_growth_report, plot_doubling_time and plot_prior_posterior.

### DIFF
--- a/R/sewer_plot.R
+++ b/R/sewer_plot.R
@@ -1011,6 +1011,7 @@ plot_doubling_time <- function(results, median = FALSE, seeding = FALSE,
     intervals = intervals
   )
   plt <- suppressMessages(plt + coord_cartesian(ylim = c(-100, 100)))
+  return(plt)
 }
 
 plot_time_series <- function(results, variable, variable_name = variable,
@@ -1243,7 +1244,7 @@ plot_LOD <- function(modeldata) {
 #'   functions to adjust themes and scales, and to add further geoms.
 #' @export
 plot_prior_posterior <- function(result, param_name) {
-  if (!(class(result) == c("EpiSewerJobResult", "list") && "summary" %in% names(result))) {
+  if (!(identical(class(result), c("EpiSewerJobResult", "list")) && "summary" %in% names(result))) {
     cli::cli_abort(paste(
       "For prior-posterior visualization,",
       "please supply an `EpiSewer` results object."
@@ -1358,7 +1359,7 @@ plot_prior_posterior <- function(result, param_name) {
 #'   adjust themes and scales, and to add further geoms.
 #' @export
 plot_growth_report <- function(result, date = NULL, partial_prob = 0.8) {
-  if (!(class(result) == c("EpiSewerJobResult", "list") && "summary" %in% names(result))) {
+  if (!(identical(class(result), c("EpiSewerJobResult", "list")) && "summary" %in% names(result))) {
     cli::cli_abort(paste(
       "For prior-posterior visualization,",
       "please supply an `EpiSewer` results object."


### PR DESCRIPTION
Hi Adrian, 

`plot_prior_posterior()` and `plot_growth_report()` both failed with the following error:

```
Error in class(result) == c("EpiSewerJobResult", "list") && "summary" %in%  : 
  'length = 2' in coercion to 'logical(1)'
```

`plot_doubling_time()` exited without generating a plot.

This is when running the data and code from the README tutorial and using R version 4.4.2 and RStudio version 2024.12.1+563.

This pull request fixes these issues.

Best,
Barbara
