### PR TITLE
Make outlier detection default

### DIFF
--- a/R/model_infections.R
+++ b/R/model_infections.R
@@ -71,8 +71,7 @@ generation_dist_assume <-
     modeldata <- tbp("generation_dist_assume",
       {
         generation_dist <- check_dist(
-          generation_dist,
-          "generation time distribution"
+          generation_dist, "generation time distribution", min_length = 2
         )
         modeldata$G <- length(generation_dist)
         modeldata$generation_dist <- generation_dist

--- a/R/model_sampling.R
+++ b/R/model_sampling.R
@@ -25,7 +25,7 @@
 #' @export
 #' @family {module functions}
 model_sampling <- function(
-    outliers = outliers_none(),
+    outliers = outliers_estimate(),
     sample_effects = sample_effects_none()
     ) {
   verify_is_modeldata(outliers, "outliers")

--- a/R/model_sampling.R
+++ b/R/model_sampling.R
@@ -247,8 +247,8 @@ outliers_estimate <- function(gev_prior_mu = 0, gev_prior_sigma = 2e-8,
     sigma = gev_prior_sigma, xi = gev_prior_xi
     )
   modeldata$.init$epsilon <- tbe(
-    rep(1e-4, modeldata$T + modeldata$D),
-    required = c("T", "D")
+    rep(1e-4, modeldata$T),
+    required = c("T")
   )
 
   modeldata$.str$sampling[["outliers"]] <- list(

--- a/R/model_sewage.R
+++ b/R/model_sewage.R
@@ -256,7 +256,9 @@ residence_dist_assume <-
   function(residence_dist = NULL, modeldata = modeldata_init()) {
     modeldata <- tbp("residence_dist_assume",
       {
-        residence_dist <- check_dist(residence_dist, "residence time distribution")
+        residence_dist <- check_dist(
+          residence_dist, "residence time distribution", min_length = 1
+          )
         modeldata$D <- length(residence_dist) - 1
         modeldata$residence_dist <- residence_dist
         return(modeldata)

--- a/R/model_shedding.R
+++ b/R/model_shedding.R
@@ -77,7 +77,7 @@ incubation_dist_assume <-
         modeldata <- tbp("incubation_dist_assume",
          {
            incubation_dist <- check_dist(
-             incubation_dist, "incubation period distribution"
+             incubation_dist, "incubation period distribution", min_length = 2
            )
            modeldata$L <- length(incubation_dist) - 1
            modeldata$incubation_dist <- incubation_dist
@@ -135,7 +135,9 @@ shedding_dist_assume <-
   function(shedding_dist = NULL, shedding_reference = NULL, modeldata = modeldata_init()) {
     modeldata <- tbp("shedding_dist_assume",
       {
-        shedding_dist <- check_dist(shedding_dist, "shedding load distribution")
+        shedding_dist <- check_dist(
+          shedding_dist, "shedding load distribution", min_length = 2
+          )
         modeldata$S <- length(shedding_dist) - 1
         modeldata$shedding_dist_type <- 0 # 0 = fixed, discrete/non-parametric
         modeldata$shedding_dist <- shedding_dist

--- a/R/utils_dists.R
+++ b/R/utils_dists.R
@@ -444,7 +444,7 @@ qexpgamma <- function(p, shape, scale) {
 
 # Distribution validation ----
 
-check_dist <- function(dist, name = "probability distribution") {
+check_dist <- function(dist, name = "probability distribution", min_length = 1) {
   if (!is.numeric(dist)) {
     cli::cli_abort(paste("Supplied", name, "is not a numeric vector."))
   }
@@ -462,9 +462,9 @@ check_dist <- function(dist, name = "probability distribution") {
     dist <- dist / sum(dist)
   }
 
-  # artificially extend dist if it has length 1 (avoids indexing issues)
-  if (length(dist) == 1 && dist == c(1)) {
-    dist <- c(1,0)
+  # artificially extend dist if it is shorter than min_length
+  if (length(dist) < min_length) {
+    dist <- c(dist, rep(0, min_length - length(dist)))
   }
 
   return(dist)

--- a/inst/stan/EpiSewer_main.stan
+++ b/inst/stan/EpiSewer_main.stan
@@ -396,7 +396,7 @@ parameters {
   vector[(cv_type == 1) && total_partitions_observe!=1 ? n_measured : 0] nu_upsilon_b_noise_raw;
   array[(cv_type == 1) && nu_upsilon_c_prior[2] > 0 ? 1 : 0] real<lower=0> nu_upsilon_c;
 
-  vector<lower=0>[outliers ? D + T : 0] epsilon; // external noise at low concentrations;
+  vector<lower=0>[outliers ? T : 0] epsilon; // external noise at low concentrations;
 }
 transformed parameters {
   // Effective reproduction number parameters ----

--- a/tests/testthat/test-fit_default.R
+++ b/tests/testthat/test-fit_default.R
@@ -39,4 +39,58 @@ test_that("Basic forecast Influenza A Zurich example works", {
 }
 )
 
+test_that("Influenza A Zurich example works with complex model", {
+  job <- EpiSewer(
+    data = ww_data_influenza_Zurich,
+    measurements = model_measurements(
+      concentrations = concentrations_observe(replicate_col = "replicate_id"),
+      noise = noise_estimate_dPCR(replicates = TRUE),
+      LOD = LOD_estimate_dPCR()
+    ),
+    sampling = model_sampling(
+      outliers = outliers_estimate(),
+      sample_effects = sample_effects_estimate_weekday(
+        effect_prior_mu = 0,
+        effect_prior_sigma = 0.4
+        )
+    ),
+    sewage = model_sewage(
+      residence_dist = residence_dist_assume(residence_dist = c(0.8, 0.2)),
+      flows = flows_observe()
+    ),
+    shedding = model_shedding(
+      load_per_case = load_per_case_calibrate(min_cases = 15),
+      load_variation = load_variation_estimate(),
+      shedding_dist = shedding_dist_estimate(
+        shedding_dist_mean_prior_mean = c(0.1, 0.12),
+        shedding_dist_mean_prior_sd = c(0.002, 0.001),
+        shedding_dist_cv_prior_mean = c(0.5, 0.6),
+        shedding_dist_cv_prior_sd = c(0.02, 0.01),
+        shedding_dist_type = "gamma",
+        shedding_reference = "symptom_onset",
+        prior_weights = c(0.7, 0.3),
+        weight_alpha = 1
+      ),
+      #shedding_dist = shedding_dist_assume(shedding_dist = ww_assumptions_influenza_Zurich$shedding_dist, shedding_reference = "symptom_onset"),
+      incubation_dist = incubation_dist_assume(incubation_dist = c(1))
+    ),
+    infections = model_infections(
+      generation_dist = generation_dist_assume(
+        generation_dist = ww_assumptions_influenza_Zurich$generation_dist
+        ),
+      R = R_estimate_gp(),
+      seeding = seeding_estimate_growth(),
+      infection_noise = infection_noise_estimate(overdispersion = TRUE)
+      ),
+    forecast = model_forecast(
+      horizon = horizon_assume(7),
+      damping = damping_assume(damping = 0.9)
+      ),
+    run_fit = FALSE
+  )
+  job <- suppressWarnings(test_run(job))
+  expect_true(check_result_has_forecast(job))
+}
+)
+
 


### PR DESCRIPTION
This PR makes `outliers_estimate()` the default option in EpiSewer, increasing the robustness of model fitting.
It also fixes a bug when using a residence time distribution together with outliers_estimate().